### PR TITLE
Fix debian jessie sources.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,13 +7,16 @@ ENV SBT_VERSION 0.13.9
 # Install Scala
 ## Piping curl directly in tar
 RUN \
+  echo 'deb http://archive.debian.org/debian jessie-backports main' > /etc/apt/sources.list.d/jessie-backports.list && \
+  sed -i '/jessie-updates/d' /etc/apt/sources.list && \
+  apt-key adv --keyserver keyserver.ubuntu.com --recv-keys AA8E81B4331F7F50 && \
+  apt-get -o Acquire::Check-Valid-Until=false update && \
   curl -fsL http://downloads.typesafe.com/scala/$SCALA_VERSION/scala-$SCALA_VERSION.tgz | tar xfz - -C /root/ && \
   echo >> /root/.bashrc && \
   echo 'export PATH=~/scala-$SCALA_VERSION/bin:$PATH' >> /root/.bashrc && \
   curl -L -o sbt-$SBT_VERSION.deb http://dl.bintray.com/sbt/debian/sbt-$SBT_VERSION.deb && \
   dpkg -i sbt-$SBT_VERSION.deb && \
   rm sbt-$SBT_VERSION.deb && \
-  apt-get update && \
   apt-get install -y sbt && \
   apt-get clean && \
   sbt sbtVersion

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ SHELL=/bin/bash -o pipefail
 # Optional tag version number to use
 DOCKER_TAG := $(or ${DOCKER_TAG},${DOCKER_TAG},latest)
 
-default: build push
+default: build
 
 build:
 	docker build -t enspirit/sbt-builder:${DOCKER_TAG} .


### PR DESCRIPTION
Debian jessie's mirrors are now archived, this PR fixes the build of sbt-builder in the same version of scala/sbt.